### PR TITLE
Changed all yii\base\Object references to yii\base\BaseObject

### DIFF
--- a/table/TableChange.php
+++ b/table/TableChange.php
@@ -2,7 +2,7 @@
 
 namespace bizley\migration\table;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class TableChange
@@ -10,7 +10,7 @@ use yii\base\Object;
  *
  * @property-read array|string|TableColumn|TablePrimaryKey|TableForeignKey|TableIndex $value
  */
-class TableChange extends Object
+class TableChange extends BaseObject
 {
     /**
      * @var string

--- a/table/TableColumn.php
+++ b/table/TableColumn.php
@@ -2,7 +2,7 @@
 
 namespace bizley\migration\table;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\db\Expression;
 
 /**
@@ -11,7 +11,7 @@ use yii\db\Expression;
  *
  * @property-read int|string $length
  */
-class TableColumn extends Object
+class TableColumn extends BaseObject
 {
     /**
      * @var string

--- a/table/TableForeignKey.php
+++ b/table/TableForeignKey.php
@@ -2,13 +2,13 @@
 
 namespace bizley\migration\table;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class TableForeignKey
  * @package bizley\migration\table
  */
-class TableForeignKey extends Object
+class TableForeignKey extends BaseObject
 {
     /**
      * @var string

--- a/table/TableIndex.php
+++ b/table/TableIndex.php
@@ -2,13 +2,13 @@
 
 namespace bizley\migration\table;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class TableIndex
  * @package bizley\migration\table
  */
-class TableIndex extends Object
+class TableIndex extends BaseObject
 {
     /**
      * @var string

--- a/table/TablePlan.php
+++ b/table/TablePlan.php
@@ -2,13 +2,13 @@
 
 namespace bizley\migration\table;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class TablePlan
  * @package bizley\migration\table
  */
-class TablePlan extends Object
+class TablePlan extends BaseObject
 {
     /**
      * @var array

--- a/table/TablePrimaryKey.php
+++ b/table/TablePrimaryKey.php
@@ -2,13 +2,13 @@
 
 namespace bizley\migration\table;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class TablePrimaryKey
  * @package bizley\migration\table
  */
-class TablePrimaryKey extends Object
+class TablePrimaryKey extends BaseObject
 {
     const GENERIC_PRIMARY_KEY = 'PRIMARYKEY';
 

--- a/table/TableStructure.php
+++ b/table/TableStructure.php
@@ -3,7 +3,7 @@
 namespace bizley\migration\table;
 
 use yii\base\InvalidParamException;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class TableStructure
@@ -11,7 +11,7 @@ use yii\base\Object;
  *
  * @property string $schema
  */
-class TableStructure extends Object
+class TableStructure extends BaseObject
 {
     const SCHEMA_MSSQL = 'mssql';
     const SCHEMA_OCI = 'oci';


### PR DESCRIPTION
From [Upgrade from Yii 2.0.12](https://github.com/yiisoft/yii2/blob/master/framework/UPGRADE.md#upgrade-from-yii-2012)
> For compatibiliy with PHP 7.2 which does not allow classes to be named Object anymore, we needed to rename `yii\base\Object` to `yii\base\BaseObject`.
> 
> yii\base\Object still exists for backwards compatibility and will be loaded if needed in projects that are running on PHP <7.2. The compatibility class `yii\base\Object` extends from yii\base\BaseObject so if you have classes that extend from `yii\base\Object` these would still work.
> 
> What does not work however will be code that relies on instanceof checks or is_subclass_of() calls for `yii\base\Object` on framework classes as these do not extend `yii\base\Object` anymore but only extend from `yii\base\BaseObject`. In general such a check is not needed as there is a `yii\base\Configurable` interface you should check against instead.

So I replaced all Object references with BaseObject