### PR TITLE
Use "confirm" instead of "prompt"

### DIFF
--- a/controllers/MigrationController.php
+++ b/controllers/MigrationController.php
@@ -382,8 +382,8 @@ class MigrationController extends Controller
             return ExitCode::OK;
         }
 
-        $prompt = $this->prompt(' > Are you sure you want to generate ' . \count($tables) . ' migrations? [y]es / [n]o', ['default' => 'n']);
-        if (strtolower($prompt) === 'y') {
+        $confirm = $this->confirm(' > Are you sure you want to generate ' . \count($tables) . ' migrations?', false);
+        if ($confirm) {
             $this->actionCreate(implode(',', $tables));
         } else {
             $this->stdout("Operation cancelled by user.\n\n", Console::FG_YELLOW);
@@ -443,8 +443,8 @@ class MigrationController extends Controller
             return ExitCode::OK;
         }
 
-        $prompt = $this->prompt(' > Are you sure you want to potentially generate ' . \count($tables) . ' migrations? [y]es / [n]o', ['default' => 'n']);
-        if (strtolower($prompt) === 'y') {
+        $confirm = $this->confirm(' > Are you sure you want to potentially generate ' . \count($tables) . ' migrations?', false);
+        if ($confirm) {
             $this->actionUpdate(implode(',', $tables));
         } else {
             $this->stdout("Operation cancelled by user.\n\n", Console::FG_YELLOW);


### PR DESCRIPTION
Issue: CLI commands `migration/create-all` and `migration/update-all` do not support `yes/no` as an input.

Solution: method `confirm` which asks user to confirm by typing `y/n` or `yes/no`: https://github.com/yiisoft/yii2/blob/master/framework/helpers/BaseConsole.php#L845

This method also appends `(yes|no)` string to the question.

