### PR TITLE
Schemas in PostgreSQL

### DIFF
--- a/src/controllers/MigrationController.php
+++ b/src/controllers/MigrationController.php
@@ -805,13 +805,15 @@ class MigrationController extends BaseMigrationController
 
     /**
      * @param Connection $db
-     * @return array
+     * @return array<string>
      * @throws NotSupportedException
      */
     public function getAllTableNames(Connection $db): array
     {
         $tables = array();
 
+        /** @var array<string>|null $schemaNames */
+        $schemaNames = array();
         try {
             $schemaNames = $db->getSchema()->getSchemaNames(true);
         } catch (NotSupportedException $ex) {

--- a/tests/functional/DbLoaderTestCase.php
+++ b/tests/functional/DbLoaderTestCase.php
@@ -76,12 +76,10 @@ abstract class DbLoaderTestCase extends DbTestCase
      * @param string $schema
      * @throws Exception
      */
-    protected function createSchema(string $schema)
+    protected function createSchema(string $schema): void
     {
-        /* Are checks for sql injection needed? */
         $this->getDb()->createCommand('CREATE SCHEMA IF NOT EXISTS ' . $schema)->execute();
     }
-
 
     /**
      * @throws NotSupportedException
@@ -193,7 +191,6 @@ abstract class DbLoaderTestCase extends DbTestCase
      */
     protected function addSchemasBase(): void
     {
-
         $this->createMigrationHistoryTable();
 
         $this->dropTable('schema2.table1');
@@ -214,8 +211,6 @@ abstract class DbLoaderTestCase extends DbTestCase
                 'col2' => $this->string(),
             ]
         );
-
-
         $this->createTable(
             'schema1.table1',
             [
@@ -232,7 +227,6 @@ abstract class DbLoaderTestCase extends DbTestCase
                 'col2' => $this->string(),
             ]
         );
-
 
         $this->getDb()
             ->createCommand()

--- a/tests/functional/DbLoaderTestCase.php
+++ b/tests/functional/DbLoaderTestCase.php
@@ -73,6 +73,17 @@ abstract class DbLoaderTestCase extends DbTestCase
     }
 
     /**
+     * @param string $schema
+     * @throws Exception
+     */
+    protected function createSchema(string $schema)
+    {
+        /* Are checks for sql injection needed? */
+        $this->getDb()->createCommand('CREATE SCHEMA IF NOT EXISTS ' . $schema)->execute();
+    }
+
+
+    /**
      * @throws NotSupportedException
      * @throws Exception
      */
@@ -170,6 +181,65 @@ abstract class DbLoaderTestCase extends DbTestCase
                 $this->historyTable,
                 [
                     'version' => 'm20200414_130200_create_table_pk_base',
+                    'apply_time' => 1586131201,
+                ]
+            )
+            ->execute();
+    }
+
+    /**
+     * @throws NotSupportedException
+     * @throws Exception
+     */
+    protected function addSchemasBase(): void
+    {
+
+        $this->createMigrationHistoryTable();
+
+        $this->dropTable('schema2.table1');
+        $this->dropTable('schema1.table1');
+        $this->dropTable('table1');
+
+        $this->createSchema('schema1');
+        $this->createSchema('schema2');
+
+        $this->getDb()->createCommand()->truncateTable($this->historyTable)->execute();
+
+        // Tables are added like this and not through the migration to skip class' autoloading.
+        $this->createTable(
+            'table1',
+            [
+                'id' => $this->primaryKey(),
+                'col' => $this->integer(),
+                'col2' => $this->string(),
+            ]
+        );
+
+
+        $this->createTable(
+            'schema1.table1',
+            [
+                'id' => $this->primaryKey(),
+                'col' => $this->integer(),
+                'col2' => $this->string(),
+            ]
+        );
+        $this->createTable(
+            'schema2.table1',
+            [
+                'id' => $this->primaryKey(),
+                'col' => $this->integer(),
+                'col2' => $this->string(),
+            ]
+        );
+
+
+        $this->getDb()
+            ->createCommand()
+            ->insert(
+                $this->historyTable,
+                [
+                    'version' => 'm20200422_210000_create_table_schemas_base',
                     'apply_time' => 1586131201,
                 ]
             )

--- a/tests/functional/pgsql/GeneratorTest.php
+++ b/tests/functional/pgsql/GeneratorTest.php
@@ -629,7 +629,6 @@ final class GeneratorTest extends \bizley\tests\functional\GeneratorTest
  > Saved as \'',
             MigrationControllerStub::$stdout
         );
-
         $this->assertStringContainsString(
             '_create_table_schema1_table.php\'
 
@@ -638,7 +637,6 @@ final class GeneratorTest extends \bizley\tests\functional\GeneratorTest
 ',
             MigrationControllerStub::$stdout
         );
-
 
         $this->assertStringContainsString(
             '_create_table_schema1_table extends Migration',
@@ -657,6 +655,5 @@ final class GeneratorTest extends \bizley\tests\functional\GeneratorTest
         );
 
         $this->getDb()->createCommand()->dropTable('schema1.table')->execute();
-
     }
 }

--- a/tests/functional/pgsql/GeneratorTest.php
+++ b/tests/functional/pgsql/GeneratorTest.php
@@ -604,4 +604,59 @@ final class GeneratorTest extends \bizley\tests\functional\GeneratorTest
         preg_match_all('/create_table_table(\d{2})/', MigrationControllerStub::$content, $matches);
         $this->assertSame(['33', '32', '31'], $matches[1]);
     }
+
+    /**
+     * @test
+     * @throws ConsoleException
+     * @throws Exception
+     * @throws InvalidRouteException
+     * @throws NotSupportedException
+     * @throws \yii\base\Exception
+     */
+    public function shouldGenerateTablesWithSchema(): void
+    {
+        $this->createSchema('schema1');
+
+        $this->createTables([
+            'schema1.table' => ['col' => $this->integer()]
+        ]);
+
+        $this->assertEquals(ExitCode::OK, $this->controller->runAction('create', ['schema1.table']));
+
+        $this->assertStringContainsString(
+            '
+ > Generating migration for creating table \'schema1.table\' ...DONE!
+ > Saved as \'',
+            MigrationControllerStub::$stdout
+        );
+
+        $this->assertStringContainsString(
+            '_create_table_schema1_table.php\'
+
+ Generated 1 file
+ (!) Remember to verify files before applying migration.
+',
+            MigrationControllerStub::$stdout
+        );
+
+
+        $this->assertStringContainsString(
+            '_create_table_schema1_table extends Migration',
+            MigrationControllerStub::$content
+        );
+        $this->assertStringContainsString(
+            '
+        $this->createTable(
+            \'{{%schema1.table}}\',
+            [
+                \'col\' => $this->integer(),
+            ],
+            $tableOptions
+        );',
+            MigrationControllerStub::$content
+        );
+
+        $this->getDb()->createCommand()->dropTable('schema1.table')->execute();
+
+    }
 }

--- a/tests/functional/pgsql/ListSchemasTest.php
+++ b/tests/functional/pgsql/ListSchemasTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace bizley\tests\functional\pgsql;
+
+use bizley\tests\functional\DbLoaderTestCase;
+use bizley\tests\stubs\MigrationControllerStub;
+use Yii;
+use yii\base\InvalidRouteException;
+use yii\base\NotSupportedException;
+use yii\console\Exception as ConsoleException;
+use yii\console\ExitCode;
+use yii\db\Exception;
+
+/** @group pgsql */
+class ListSchemasTest extends DbLoaderTestCase
+{
+    /** @var MigrationControllerStub */
+    protected $controller;
+    /** @var string */
+    public static $schema = 'pgsql';
+
+    /**
+     * @throws NotSupportedException
+     * @throws Exception
+     */
+    protected function setUp(): void
+    {
+        $this->controller = new MigrationControllerStub('migration', Yii::$app);
+        $this->controller->migrationPath = '@bizley/tests/migrations';
+        MigrationControllerStub::$stdout = '';
+        MigrationControllerStub::$content = '';
+        MigrationControllerStub::$confirmControl = true;
+
+        $this->addSchemasBase();
+    }
+
+    /**
+     * @test
+     * @throws InvalidRouteException
+     * @throws ConsoleException
+     */
+    public function shouldShowListActionWithAllTables(): void
+    {
+        $this->assertEquals(ExitCode::OK, $this->controller->runAction('list'));
+
+        $this->assertStringContainsString('Yii 2 Migration Generator Tool v', MigrationControllerStub::$stdout);
+        $this->assertStringContainsString(' > Your database contains ', MigrationControllerStub::$stdout);
+        $this->assertStringContainsString('   - table1', MigrationControllerStub::$stdout);
+        $this->assertStringContainsString('   - schema1.table1', MigrationControllerStub::$stdout);
+        $this->assertStringContainsString('   - schema2.table1', MigrationControllerStub::$stdout);
+        $this->assertStringContainsString(
+            '
+ > Run
+   migration/create <table>
+      to generate creating migration for the specific table.
+   migration/update <table>
+      to generate updating migration for the specific table.
+
+ > <table> can be:
+   - * (asterisk) - for all the tables in database (except excluded ones)
+   - string with * (one or more) - for all the tables in database matching the pattern (except excluded ones)
+   - string without * - for the table of specified name
+   - strings separated with comma - for multiple tables of specified names (with optional *)
+',
+            MigrationControllerStub::$stdout
+        );
+    }
+}

--- a/tests/functional/pgsql/UpdaterSchemasTest.php
+++ b/tests/functional/pgsql/UpdaterSchemasTest.php
@@ -190,5 +190,4 @@ class UpdaterSchemasTest extends DbLoaderTestCase
             MigrationControllerStub::$content
         );
     }
-
 }

--- a/tests/functional/pgsql/UpdaterSchemasTest.php
+++ b/tests/functional/pgsql/UpdaterSchemasTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace bizley\tests\functional\pgsql;
+
+use bizley\tests\functional\DbLoaderTestCase;
+use bizley\tests\stubs\MigrationControllerStub;
+use Yii;
+use yii\base\Exception;
+use yii\base\InvalidRouteException;
+use yii\base\NotSupportedException;
+use yii\console\Exception as ConsoleException;
+use yii\console\ExitCode;
+use yii\db\Exception as DbException;
+
+/** @group pgsql */
+class UpdaterSchemasTest extends DbLoaderTestCase
+{
+    /** @var MigrationControllerStub */
+    protected $controller;
+    /** @var string */
+    public static $schema = 'pgsql';
+
+    /**
+     * @throws NotSupportedException
+     * @throws DbException
+     */
+    protected function setUp(): void
+    {
+        $this->controller = new MigrationControllerStub('migration', Yii::$app);
+        $this->controller->migrationPath = '@bizley/tests/migrations';
+        MigrationControllerStub::$stdout = '';
+        MigrationControllerStub::$content = '';
+        MigrationControllerStub::$confirmControl = true;
+
+        $this->addSchemasBase();
+    }
+
+    /**
+     * @test
+     * @throws ConsoleException
+     * @throws InvalidRouteException
+     * @throws Exception
+     */
+    public function shouldFindMatchingSchemasTables(): void
+    {
+        MigrationControllerStub::$confirmControl = false;
+        $this->assertEquals(ExitCode::OK, $this->controller->runAction('update', ['schema*']));
+        $this->assertStringContainsString(
+            ' > 1 table excluded by the config.
+ > Are you sure you want to generate migrations for the following tables?
+   - schema1.table1
+   - schema2.table1
+ Operation cancelled by user.
+',
+            MigrationControllerStub::$stdout
+        );
+    }
+
+    /**
+     * @test
+     * @throws ConsoleException
+     * @throws InvalidRouteException
+     * @throws Exception
+     */
+    public function shouldFindMatchingTablesWithoutSchemasToo(): void
+    {
+        $this->createTables([
+            'schematable' => ['col' => $this->integer()]
+        ]);
+
+        MigrationControllerStub::$confirmControl = false;
+        $this->assertEquals(ExitCode::OK, $this->controller->runAction('update', ['schema*']));
+        $this->assertStringContainsString(
+            ' > 1 table excluded by the config.
+ > Are you sure you want to generate migrations for the following tables?
+   - schematable
+   - schema1.table1
+   - schema2.table1
+ Operation cancelled by user.
+',
+            MigrationControllerStub::$stdout
+        );
+
+        $this->getDb()->createCommand()->dropTable('schematable')->execute();
+    }
+
+    /**
+     * @test
+     * @throws ConsoleException
+     * @throws InvalidRouteException
+     * @throws Exception
+     */
+    public function shouldCreateNewSchemaTable(): void
+    {
+        $this->createSchema('test');
+        $this->createTables([
+            'test.table' => ['col' => $this->integer()]
+        ]);
+        $transaction = $this->getDb()->getTransaction();
+        if ($transaction) {
+            $transaction->commit();
+        }
+
+        $this->assertEquals(ExitCode::OK, $this->controller->runAction('update', ['test.table']));
+        $this->assertStringContainsString(
+            ' > 1 table excluded by the config.
+
+ > Comparing current table \'test.table\' with its migrations ...DONE!
+
+ > Generating migration for creating table \'test.table\' ...DONE!
+ > Saved as \'',
+            MigrationControllerStub::$stdout
+        );
+
+        $this->assertStringContainsString(
+            '_create_table_test_table.php\'
+
+ Generated 1 file
+ (!) Remember to verify files before applying migration.
+',
+            MigrationControllerStub::$stdout
+        );
+        $this->assertStringContainsString(
+            '_create_table_test_table extends Migration',
+            MigrationControllerStub::$content
+        );
+        $this->assertStringContainsString(
+            '
+        $this->createTable(
+            \'{{%test.table}}\',
+            [
+                \'col\' => $this->integer(),
+            ],
+            $tableOptions
+        );
+    }
+
+    public function down()
+    {
+        $this->dropTable(\'{{%test.table}}\');
+    }',
+            MigrationControllerStub::$content
+        );
+    }
+
+    /**
+     * @test
+     * @throws ConsoleException
+     * @throws InvalidRouteException
+     * @throws Exception
+     */
+    public function shouldUpdateSchemaTable(): void
+    {
+        $this->getDb()->createCommand()->addColumn('schema1.table1', 'added', $this->integer())->execute();
+
+        $this->assertEquals(ExitCode::OK, $this->controller->runAction('update', ['schema1.table1']));
+        $this->assertStringContainsString(
+            ' > 1 table excluded by the config.
+
+ > Comparing current table \'schema1.table1\' with its migrations ...DONE!
+
+ > Generating migration for updating table \'schema1.table1\' ...DONE!
+ > Saved as \'',
+            MigrationControllerStub::$stdout
+        );
+        $this->assertStringContainsString(
+            '_update_table_schema1_table1.php\'
+
+ Generated 1 file
+ (!) Remember to verify files before applying migration.
+',
+            MigrationControllerStub::$stdout
+        );
+        $this->assertStringContainsString(
+            '_update_table_schema1_table1 extends Migration',
+            MigrationControllerStub::$content
+        );
+        $this->assertStringContainsString(
+            'public function up()
+    {
+        $this->addColumn(\'{{%schema1.table1}}\', \'added\', $this->integer()->after(\'col2\'));
+    }
+
+    public function down()
+    {
+        $this->dropColumn(\'{{%schema1.table1}}\', \'added\');
+    }',
+            MigrationControllerStub::$content
+        );
+    }
+
+}

--- a/tests/migrations/m20200422_210000_create_table_schemas_base.php
+++ b/tests/migrations/m20200422_210000_create_table_schemas_base.php
@@ -1,0 +1,51 @@
+<?php
+
+use yii\db\Migration;
+
+class m20200422_210000_create_table_schemas_base extends Migration
+{
+    public function up()
+    {
+        $tableOptions = null;
+        if ($this->db->driverName === 'mysql') {
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
+        }
+
+        $this->createTable(
+            'table1',
+            [
+                'id' => $this->primaryKey(),
+                'col' => $this->integer(),
+                'col2' => $this->string(),
+            ],
+            $tableOptions
+        );
+
+
+        $this->createTable(
+            'schema1.table1',
+            [
+                'id' => $this->primaryKey(),
+                'col' => $this->integer(),
+                'col2' => $this->string(),
+            ],
+            $tableOptions
+        );
+        $this->createTable(
+            'schema2.table1',
+            [
+                'id' => $this->primaryKey(),
+                'col' => $this->integer(),
+                'col2' => $this->string(),
+            ],
+            $tableOptions
+        );
+    }
+
+    public function down()
+    {
+        $this->dropTable('schema2.table1');
+        $this->dropTable('schema1.table1');
+        $this->dropTable('table1');
+    }
+}

--- a/tests/migrations/m20200422_210000_create_table_schemas_base.php
+++ b/tests/migrations/m20200422_210000_create_table_schemas_base.php
@@ -21,7 +21,6 @@ class m20200422_210000_create_table_schemas_base extends Migration
             $tableOptions
         );
 
-
         $this->createTable(
             'schema1.table1',
             [


### PR DESCRIPTION
Currently command `list` shows tables only from `public` scheme.  
And if you create migration for table from another scheme like `schemename.tablename` it will have `.` in migration class name, which breaks php code.

I have tried to fix these issues. Though not sure if i done tests right.