### PR TITLE
PHP84Fixes: Implicitly marking parameter as nullable is deprecated fixes

### DIFF
--- a/src/Arranger.php
+++ b/src/Arranger.php
@@ -44,7 +44,7 @@ final class Arranger implements ArrangerInterface
     /**
      * Adds dependency of the table.
      */
-    private function addDependency(string $table, string $dependsOnTable = null): void
+    private function addDependency(string $table, ?string $dependsOnTable = null): void
     {
         if (!\array_key_exists($table, $this->dependencies)) {
             $this->dependencies[$table] = [];

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -72,7 +72,7 @@ final class Generator implements GeneratorInterface
         array $referencesToPostpone = [],
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string {
         if ($this->tableMapper->getTableSchema($tableName) === null) {
             throw new TableMissingException("Table '$tableName' does not exists!");
@@ -116,7 +116,7 @@ final class Generator implements GeneratorInterface
         string $migrationName,
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string {
         return $this->view->renderFile(
             $this->getCreateForeignKeysMigrationTemplate(),

--- a/src/GeneratorInterface.php
+++ b/src/GeneratorInterface.php
@@ -21,7 +21,7 @@ interface GeneratorInterface
         array $referencesToPostpone = [],
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string;
 
     /**
@@ -33,7 +33,7 @@ interface GeneratorInterface
         string $migrationName,
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string;
 
     /**

--- a/src/HistoryManager.php
+++ b/src/HistoryManager.php
@@ -63,7 +63,7 @@ final class HistoryManager implements HistoryManagerInterface
      * @throws Exception
      * @throws NotSupportedException
      */
-    public function addHistory(string $migrationName, string $namespace = null): void
+    public function addHistory(string $migrationName, ?string $namespace = null): void
     {
         if ($this->db->getSchema()->getTableSchema($this->historyTable, true) === null) {
             $this->createTable();

--- a/src/HistoryManagerInterface.php
+++ b/src/HistoryManagerInterface.php
@@ -14,7 +14,7 @@ interface HistoryManagerInterface
      * @throws Exception
      * @throws NotSupportedException
      */
-    public function addHistory(string $migrationName, string $namespace = null): void;
+    public function addHistory(string $migrationName, ?string $namespace = null): void;
 
     /**
      * Returns the migration history.

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -174,7 +174,7 @@ final class Schema
      * Returns default length based on the schema and column type.
      * For MySQL >= 5.6.4 additional default sizes are available.
      */
-    public static function getDefaultLength(?string $schema, string $type, string $engineVersion = null): ?string
+    public static function getDefaultLength(?string $schema, string $type, ?string $engineVersion = null): ?string
     {
         if ($schema === null) {
             return null;

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -92,7 +92,7 @@ final class Updater implements UpdaterInterface
         string $migrationName,
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string {
         return $this->view->renderFile(
             $this->getUpdateTableMigrationTemplate(),

--- a/src/UpdaterInterface.php
+++ b/src/UpdaterInterface.php
@@ -36,6 +36,6 @@ interface UpdaterInterface
         string $migrationName,
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string;
 }

--- a/src/controllers/MigrationController.php
+++ b/src/controllers/MigrationController.php
@@ -802,7 +802,7 @@ class MigrationController extends BaseMigrationController
      * @return array<string>
      */
     private function findMatchingTables(
-        string $pattern = null,
+        ?string $pattern = null,
         array $allTables = [],
         array $excludedTables = []
     ): array {

--- a/src/dummy/MigrationChanges.php
+++ b/src/dummy/MigrationChanges.php
@@ -306,7 +306,7 @@ class Migration extends Component implements MigrationChangesInterface
      * @param array<string, string|ColumnSchemaBuilder> $columns
      * @throws ReflectionException
      */
-    public function createTable(string $table, array $columns, string $options = null): void
+    public function createTable(string $table, array $columns, ?string $options = null): void
     {
         $this->addChange($table, 'createTable', $this->extractColumns($columns));
     }
@@ -403,8 +403,8 @@ class Migration extends Component implements MigrationChangesInterface
         $columns,
         string $refTable,
         $refColumns,
-        string $delete = null,
-        string $update = null
+        ?string $delete = null,
+        ?string $update = null
     ): void {
         $columns = \is_array($columns) ? $columns : \preg_split('/\s*,\s*/', $columns);
         $this->addChange(

--- a/src/dummy/MigrationSql.php
+++ b/src/dummy/MigrationSql.php
@@ -122,7 +122,7 @@ class Migration extends Component implements MigrationSqlInterface
     }
 
     /** @param array<string, string|ColumnSchemaBuilder> $columns */
-    public function createTable(string $table, array $columns, string $options = null): void
+    public function createTable(string $table, array $columns, ?string $options = null): void
     {
         $this->statements[] = $this->db->createCommand()->createTable($table, $columns, $options)->getRawSql();
         foreach ($columns as $column => $type) {
@@ -205,8 +205,8 @@ class Migration extends Component implements MigrationSqlInterface
         $columns,
         string $refTable,
         $refColumns,
-        string $delete = null,
-        string $update = null
+        ?string $delete = null,
+        ?string $update = null
     ): void {
         $this->statements[] = $this->db
             ->createCommand()

--- a/src/renderers/BlueprintRenderer.php
+++ b/src/renderers/BlueprintRenderer.php
@@ -39,10 +39,10 @@ final class BlueprintRenderer implements BlueprintRendererInterface
     public function renderUp(
         BlueprintInterface $blueprint,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null,
+        ?string $schema = null,
+        ?string $engineVersion = null,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): string {
         $tableName = $this->renderName($blueprint->getTableName(), $usePrefix, $dbPrefix);
 
@@ -70,10 +70,10 @@ final class BlueprintRenderer implements BlueprintRendererInterface
     public function renderDown(
         BlueprintInterface $blueprint,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null,
+        ?string $schema = null,
+        ?string $engineVersion = null,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): string {
         $tableName = $this->renderName($blueprint->getTableName(), $usePrefix, $dbPrefix);
 
@@ -99,7 +99,7 @@ final class BlueprintRenderer implements BlueprintRendererInterface
      * detected, prefix is removed from the name and replaced by a prefix structure ({{%}}).
      * @param bool $usePrefix whether to add prefix structure to the name
      */
-    public function renderName(string $tableName, bool $usePrefix, string $dbPrefix = null): string
+    public function renderName(string $tableName, bool $usePrefix, ?string $dbPrefix = null): string
     {
         if ($usePrefix === false) {
             return $tableName;
@@ -143,8 +143,8 @@ final class BlueprintRenderer implements BlueprintRendererInterface
         BlueprintInterface $blueprint,
         string $tableName,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null,
+        ?string $schema = null,
+        ?string $engineVersion = null,
         bool $inverse = false
     ): ?string {
         $renderedColumns = [];
@@ -178,8 +178,8 @@ final class BlueprintRenderer implements BlueprintRendererInterface
         BlueprintInterface $blueprint,
         string $tableName,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null,
+        ?string $schema = null,
+        ?string $engineVersion = null,
         bool $inverse = false
     ): ?string {
         $renderedColumns = [];
@@ -213,7 +213,7 @@ final class BlueprintRenderer implements BlueprintRendererInterface
         BlueprintInterface $blueprint,
         string $tableName,
         int $indent = 0,
-        string $schema = null,
+        ?string $schema = null,
         bool $inverse = false
     ): ?string {
         $renderedForeignKeys = [];
@@ -238,9 +238,9 @@ final class BlueprintRenderer implements BlueprintRendererInterface
         BlueprintInterface $blueprint,
         string $tableName,
         int $indent = 0,
-        string $schema = null,
+        ?string $schema = null,
         bool $usePrefix = true,
-        string $dbPrefix = null,
+        ?string $dbPrefix = null,
         bool $inverse = false
     ): ?string {
         $renderedForeignKeys = [];
@@ -319,7 +319,7 @@ final class BlueprintRenderer implements BlueprintRendererInterface
         BlueprintInterface $blueprint,
         string $tableName,
         int $indent = 0,
-        string $schema = null,
+        ?string $schema = null,
         bool $inverse = false
     ): ?string {
         if ($inverse) {
@@ -338,7 +338,7 @@ final class BlueprintRenderer implements BlueprintRendererInterface
         BlueprintInterface $blueprint,
         string $tableName,
         int $indent = 0,
-        string $schema = null,
+        ?string $schema = null,
         bool $inverse = false
     ): ?string {
         if ($inverse) {

--- a/src/renderers/BlueprintRendererInterface.php
+++ b/src/renderers/BlueprintRendererInterface.php
@@ -15,10 +15,10 @@ interface BlueprintRendererInterface
     public function renderUp(
         BlueprintInterface $blueprint,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null,
+        ?string $schema = null,
+        ?string $engineVersion = null,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): string;
 
     /**
@@ -28,9 +28,9 @@ interface BlueprintRendererInterface
     public function renderDown(
         BlueprintInterface $blueprint,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null,
+        ?string $schema = null,
+        ?string $engineVersion = null,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): string;
 }

--- a/src/renderers/ColumnRenderer.php
+++ b/src/renderers/ColumnRenderer.php
@@ -51,10 +51,10 @@ final class ColumnRenderer implements ColumnRendererInterface
      */
     public function render(
         ColumnInterface $column,
-        PrimaryKeyInterface $primaryKey = null,
+        ?PrimaryKeyInterface $primaryKey = null,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): ?string {
         $template = \str_repeat(' ', $indent) . $this->definitionTemplate;
 
@@ -77,10 +77,10 @@ final class ColumnRenderer implements ColumnRendererInterface
     public function renderAdd(
         ColumnInterface $column,
         string $tableName,
-        PrimaryKeyInterface $primaryKey = null,
+        ?PrimaryKeyInterface $primaryKey = null,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): ?string {
         $template = \str_repeat(' ', $indent) . $this->addColumnTemplate;
 
@@ -105,10 +105,10 @@ final class ColumnRenderer implements ColumnRendererInterface
     public function renderAlter(
         ColumnInterface $column,
         string $tableName,
-        PrimaryKeyInterface $primaryKey = null,
+        ?PrimaryKeyInterface $primaryKey = null,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): ?string {
         $template = \str_repeat(' ', $indent) . $this->alterColumnTemplate;
 
@@ -152,9 +152,9 @@ final class ColumnRenderer implements ColumnRendererInterface
      */
     public function renderDefinition(
         ColumnInterface $column,
-        PrimaryKeyInterface $primaryKey = null,
-        string $schema = null,
-        string $engineVersion = null
+        ?PrimaryKeyInterface $primaryKey = null,
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): ?string {
         $this->definition = [];
         $this->isPrimaryKeyPossible = true;
@@ -173,8 +173,8 @@ final class ColumnRenderer implements ColumnRendererInterface
     private function buildColumnDefinition(
         ColumnInterface $column,
         ?PrimaryKeyInterface $primaryKey,
-        string $schema = null,
-        string $engineVersion = null
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): void {
         $definition = $column->getDefinition();
 
@@ -239,7 +239,7 @@ final class ColumnRenderer implements ColumnRendererInterface
     private function buildGeneralDefinition(
         ColumnInterface $column,
         ?PrimaryKeyInterface $primaryKey,
-        string $schema = null
+        ?string $schema = null
     ): void {
         \array_unshift($this->definition, '$this');
 

--- a/src/renderers/ColumnRendererInterface.php
+++ b/src/renderers/ColumnRendererInterface.php
@@ -14,10 +14,10 @@ interface ColumnRendererInterface
      */
     public function render(
         ColumnInterface $column,
-        PrimaryKeyInterface $primaryKey = null,
+        ?PrimaryKeyInterface $primaryKey = null,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): ?string;
 
     /**
@@ -25,9 +25,9 @@ interface ColumnRendererInterface
      */
     public function renderDefinition(
         ColumnInterface $column,
-        PrimaryKeyInterface $primaryKey = null,
-        string $schema = null,
-        string $engineVersion = null
+        ?PrimaryKeyInterface $primaryKey = null,
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): ?string;
 
     /**
@@ -36,10 +36,10 @@ interface ColumnRendererInterface
     public function renderAdd(
         ColumnInterface $column,
         string $tableName,
-        PrimaryKeyInterface $primaryKey = null,
+        ?PrimaryKeyInterface $primaryKey = null,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): ?string;
 
     /**
@@ -48,10 +48,10 @@ interface ColumnRendererInterface
     public function renderAlter(
         ColumnInterface $column,
         string $tableName,
-        PrimaryKeyInterface $primaryKey = null,
+        ?PrimaryKeyInterface $primaryKey = null,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): ?string;
 
     /**

--- a/src/renderers/ForeignKeyRenderer.php
+++ b/src/renderers/ForeignKeyRenderer.php
@@ -43,7 +43,7 @@ TEMPLATE;
         string $tableName,
         string $referencedTableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): string {
         if ($schema === Schema::SQLITE && $this->generalSchema === false) {
             throw new NotSupportedException('ADD FOREIGN KEY is not supported by SQLite.');
@@ -97,7 +97,7 @@ TEMPLATE;
         ForeignKeyInterface $foreignKey,
         string $tableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): string {
         if ($schema === Schema::SQLITE && $this->generalSchema === false) {
             throw new NotSupportedException('DROP FOREIGN KEY is not supported by SQLite.');

--- a/src/renderers/ForeignKeyRendererInterface.php
+++ b/src/renderers/ForeignKeyRendererInterface.php
@@ -16,7 +16,7 @@ interface ForeignKeyRendererInterface
         string $tableName,
         string $referencedTableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): string;
 
     /**
@@ -26,6 +26,6 @@ interface ForeignKeyRendererInterface
         ForeignKeyInterface $foreignKey,
         string $tableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): string;
 }

--- a/src/renderers/PrimaryKeyRenderer.php
+++ b/src/renderers/PrimaryKeyRenderer.php
@@ -32,7 +32,7 @@ final class PrimaryKeyRenderer implements PrimaryKeyRendererInterface
         ?PrimaryKeyInterface $primaryKey,
         string $tableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): ?string {
         if ($primaryKey === null || !$primaryKey->isComposite()) {
             return null;
@@ -73,7 +73,7 @@ final class PrimaryKeyRenderer implements PrimaryKeyRendererInterface
         ?PrimaryKeyInterface $primaryKey,
         string $tableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): ?string {
         if ($primaryKey === null || !$primaryKey->isComposite()) {
             return null;

--- a/src/renderers/PrimaryKeyRendererInterface.php
+++ b/src/renderers/PrimaryKeyRendererInterface.php
@@ -15,7 +15,7 @@ interface PrimaryKeyRendererInterface
         ?PrimaryKeyInterface $primaryKey,
         string $tableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): ?string;
 
     /**
@@ -25,6 +25,6 @@ interface PrimaryKeyRendererInterface
         ?PrimaryKeyInterface $primaryKey,
         string $tableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): ?string;
 }

--- a/src/renderers/StructureRenderer.php
+++ b/src/renderers/StructureRenderer.php
@@ -56,7 +56,7 @@ TEMPLATE;
      * Renders table name. Name should be provided without the prefix. If name should be with prefix and it is being
      * detected, prefix is removed from the name and replaced by a prefix structure ({{%}}).
      */
-    public function renderName(string $tableName, bool $usePrefix, string $dbPrefix = null): string
+    public function renderName(string $tableName, bool $usePrefix, ?string $dbPrefix = null): string
     {
         if ($usePrefix === false) {
             return $tableName;
@@ -76,10 +76,10 @@ TEMPLATE;
     public function renderStructureUp(
         StructureInterface $structure,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null,
+        ?string $schema = null,
+        ?string $engineVersion = null,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): string {
         $tableName = $this->renderName($structure->getName(), $usePrefix, $dbPrefix);
 
@@ -103,7 +103,7 @@ TEMPLATE;
         StructureInterface $structure,
         int $indent = 0,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): string {
         return $this->renderStructureTableDown(
             $this->renderName($structure->getName(), $usePrefix, $dbPrefix),
@@ -137,8 +137,8 @@ TEMPLATE;
         StructureInterface $structure,
         string $tableName,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null
+        ?string $schema = null,
+        ?string $engineVersion = null
     ): string {
         $columns = $structure->getColumns();
         $renderedColumns = [];
@@ -187,7 +187,7 @@ TEMPLATE;
         StructureInterface $structure,
         string $tableName,
         int $indent = 0,
-        string $schema = null
+        ?string $schema = null
     ): ?string {
         return $this->primaryKeyRenderer->renderUp($structure->getPrimaryKey(), $tableName, $indent, $schema);
     }
@@ -229,8 +229,8 @@ TEMPLATE;
         StructureInterface $structure,
         int $indent = 0,
         bool $usePrefix = true,
-        string $dbPrefix = null,
-        string $schema = null
+        ?string $dbPrefix = null,
+        ?string $schema = null
     ): ?string {
         return $this->renderForeignKeysUp(
             $structure->getForeignKeys(),
@@ -249,8 +249,8 @@ TEMPLATE;
         array $foreignKeys,
         int $indent = 0,
         bool $usePrefix = true,
-        string $dbPrefix = null,
-        string $schema = null
+        ?string $dbPrefix = null,
+        ?string $schema = null
     ): ?string {
         $renderedForeignKeys = [];
         foreach ($foreignKeys as $foreignKey) {
@@ -274,8 +274,8 @@ TEMPLATE;
         array $foreignKeys,
         int $indent = 0,
         bool $usePrefix = true,
-        string $dbPrefix = null,
-        string $schema = null
+        ?string $dbPrefix = null,
+        ?string $schema = null
     ): ?string {
         $renderedForeignKeys = [];
         foreach ($foreignKeys as $foreignKey) {

--- a/src/renderers/StructureRendererInterface.php
+++ b/src/renderers/StructureRendererInterface.php
@@ -16,10 +16,10 @@ interface StructureRendererInterface
     public function renderStructureUp(
         StructureInterface $structure,
         int $indent = 0,
-        string $schema = null,
-        string $engineVersion = null,
+        ?string $schema = null,
+        ?string $engineVersion = null,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): string;
 
     /**
@@ -30,14 +30,14 @@ interface StructureRendererInterface
         StructureInterface $structure,
         int $indent = 0,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): string;
 
     /**
      * Renders table name. Name should be provided without the prefix. If name should be with prefix and it is being
      * detected, prefix is removed from the name and replaced by a prefix structure ({{%}}).
      */
-    public function renderName(string $tableName, bool $usePrefix, string $dbPrefix = null): string;
+    public function renderName(string $tableName, bool $usePrefix, ?string $dbPrefix = null): string;
 
     /**
      * Renders the add foreign keys statements (direct).
@@ -47,8 +47,8 @@ interface StructureRendererInterface
         array $foreignKeys,
         int $indent = 0,
         bool $usePrefix = true,
-        string $dbPrefix = null,
-        string $schema = null
+        ?string $dbPrefix = null,
+        ?string $schema = null
     ): ?string;
 
     /**
@@ -59,6 +59,6 @@ interface StructureRendererInterface
         array $foreignKeys,
         int $indent = 0,
         bool $usePrefix = true,
-        string $dbPrefix = null
+        ?string $dbPrefix = null
     ): ?string;
 }

--- a/src/table/BigIntegerColumn.php
+++ b/src/table/BigIntegerColumn.php
@@ -28,7 +28,7 @@ final class BigIntegerColumn extends Column implements PrimaryKeyVariantColumnIn
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->isSchemaLengthSupporting($schema, $engineVersion) ? $this->getSize() : null;
     }
@@ -37,7 +37,7 @@ final class BigIntegerColumn extends Column implements PrimaryKeyVariantColumnIn
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
             $this->setSize($value);

--- a/src/table/BigPrimaryKeyColumn.php
+++ b/src/table/BigPrimaryKeyColumn.php
@@ -28,7 +28,7 @@ class BigPrimaryKeyColumn extends Column implements PrimaryKeyColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->isSchemaLengthSupporting($schema, $engineVersion) ? $this->getSize() : null;
     }
@@ -37,7 +37,7 @@ class BigPrimaryKeyColumn extends Column implements PrimaryKeyColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
             $this->setSize($value);

--- a/src/table/BinaryColumn.php
+++ b/src/table/BinaryColumn.php
@@ -15,7 +15,7 @@ final class BinaryColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return \in_array($schema, $this->lengthSchemas, true) ? $this->getSize() : null;
     }
@@ -24,7 +24,7 @@ final class BinaryColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if (\in_array($schema, $this->lengthSchemas, true)) {
             $this->setSize($value);

--- a/src/table/BooleanColumn.php
+++ b/src/table/BooleanColumn.php
@@ -18,7 +18,7 @@ final class BooleanColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return \in_array($schema, $this->lengthSchemas, true) ? $this->getSize() : null;
     }
@@ -27,7 +27,7 @@ final class BooleanColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if (\in_array($schema, $this->lengthSchemas, true)) {
             $this->setSize($value);

--- a/src/table/CharacterColumn.php
+++ b/src/table/CharacterColumn.php
@@ -10,7 +10,7 @@ final class CharacterColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->getSize();
     }
@@ -19,7 +19,7 @@ final class CharacterColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         $this->setSize($value);
         $this->setPrecision($value);

--- a/src/table/Column.php
+++ b/src/table/Column.php
@@ -332,7 +332,7 @@ abstract class Column
      * @param bool $primaryKey whether the column is primary key
      * @param bool $autoIncrement whether the column has autoincrement flag
      */
-    public function prepareSchemaAppend(bool $primaryKey, bool $autoIncrement, string $schema = null): ?string
+    public function prepareSchemaAppend(bool $primaryKey, bool $autoIncrement, ?string $schema = null): ?string
     {
         switch ($schema) {
             case Schema::MSSQL:
@@ -406,11 +406,11 @@ abstract class Column
      * Returns length of the column.
      * @return string|int|null
      */
-    abstract public function getLength(string $schema = null, string $engineVersion = null);
+    abstract public function getLength(?string $schema = null, ?string $engineVersion = null);
 
     /**
      * Sets length for the column.
      * @param string|int|array<string|int>|null $value
      */
-    abstract public function setLength($value, string $schema = null, string $engineVersion = null): void;
+    abstract public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void;
 }

--- a/src/table/ColumnInterface.php
+++ b/src/table/ColumnInterface.php
@@ -51,7 +51,7 @@ interface ColumnInterface
      * @param bool $primaryKey whether the column is primary key
      * @param bool $autoIncrement whether the column has autoincrement flag
      */
-    public function prepareSchemaAppend(bool $primaryKey, bool $autoIncrement, string $schema = null): ?string;
+    public function prepareSchemaAppend(bool $primaryKey, bool $autoIncrement, ?string $schema = null): ?string;
 
     /**
      * Removes information of primary key in append statement and returns what is left.
@@ -150,13 +150,13 @@ interface ColumnInterface
      * Returns length of the column.
      * @return string|int|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null);
+    public function getLength(?string $schema = null, ?string $engineVersion = null);
 
     /**
      * Sets length for the column.
      * @param string|int|array<string|int>|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void;
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void;
 
     /**
      * Returns default column definition.

--- a/src/table/DateColumn.php
+++ b/src/table/DateColumn.php
@@ -10,14 +10,14 @@ final class DateColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param mixed $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
     }
 
     /**
      * Returns length of the column.
      */
-    public function getLength(string $schema = null, string $engineVersion = null): ?int
+    public function getLength(?string $schema = null, ?string $engineVersion = null): ?int
     {
         return null;
     }

--- a/src/table/DateTimeColumn.php
+++ b/src/table/DateTimeColumn.php
@@ -30,7 +30,7 @@ final class DateTimeColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->isSchemaLengthSupporting($schema, $engineVersion) ? $this->getPrecision() : null;
     }
@@ -39,7 +39,7 @@ final class DateTimeColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
             $this->setPrecision($value);

--- a/src/table/DecimalColumn.php
+++ b/src/table/DecimalColumn.php
@@ -21,7 +21,7 @@ final class DecimalColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         if (!\in_array($schema, $this->lengthSchemas, true)) {
             return null;
@@ -35,7 +35,7 @@ final class DecimalColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|array<string|int>|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if (\in_array($schema, $this->lengthSchemas, true)) {
             if (\is_array($value)) {

--- a/src/table/DoubleColumn.php
+++ b/src/table/DoubleColumn.php
@@ -15,7 +15,7 @@ final class DoubleColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return \in_array($schema, $this->lengthSchemas, true) ? $this->getPrecision() : null;
     }
@@ -24,7 +24,7 @@ final class DoubleColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if (\in_array($schema, $this->lengthSchemas, true)) {
             $this->setPrecision($value);

--- a/src/table/FloatColumn.php
+++ b/src/table/FloatColumn.php
@@ -15,7 +15,7 @@ final class FloatColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return \in_array($schema, $this->lengthSchemas, true) ? $this->getPrecision() : null;
     }
@@ -24,7 +24,7 @@ final class FloatColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if (\in_array($schema, $this->lengthSchemas, true)) {
             $this->setPrecision($value);

--- a/src/table/IntegerColumn.php
+++ b/src/table/IntegerColumn.php
@@ -28,7 +28,7 @@ final class IntegerColumn extends Column implements PrimaryKeyVariantColumnInter
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->isSchemaLengthSupporting($schema, $engineVersion) ? $this->getSize() : null;
     }
@@ -37,7 +37,7 @@ final class IntegerColumn extends Column implements PrimaryKeyVariantColumnInter
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
             $this->setSize($value);

--- a/src/table/JsonColumn.php
+++ b/src/table/JsonColumn.php
@@ -24,7 +24,7 @@ final class JsonColumn extends Column implements ColumnInterface
     /**
      * Returns length of the column.
      */
-    public function getLength(string $schema = null, string $engineVersion = null): ?int
+    public function getLength(?string $schema = null, ?string $engineVersion = null): ?int
     {
         return null;
     }
@@ -33,7 +33,7 @@ final class JsonColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param mixed $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
     }
 

--- a/src/table/MoneyColumn.php
+++ b/src/table/MoneyColumn.php
@@ -10,7 +10,7 @@ final class MoneyColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         $scale = $this->getScale();
         return $this->getPrecision() . ($scale !== null ? ', ' . $scale : null);
@@ -20,7 +20,7 @@ final class MoneyColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|array<string|int>|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if (\is_array($value)) {
             $length = $value;

--- a/src/table/PrimaryKeyColumn.php
+++ b/src/table/PrimaryKeyColumn.php
@@ -28,7 +28,7 @@ class PrimaryKeyColumn extends Column implements PrimaryKeyColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->isSchemaLengthSupporting($schema, $engineVersion) ? $this->getSize() : null;
     }
@@ -37,7 +37,7 @@ class PrimaryKeyColumn extends Column implements PrimaryKeyColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
             $this->setSize($value);

--- a/src/table/SmallIntegerColumn.php
+++ b/src/table/SmallIntegerColumn.php
@@ -28,7 +28,7 @@ final class SmallIntegerColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->isSchemaLengthSupporting($schema, $engineVersion) ? $this->getSize() : null;
     }
@@ -37,7 +37,7 @@ final class SmallIntegerColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
             $this->setSize($value);

--- a/src/table/StringColumn.php
+++ b/src/table/StringColumn.php
@@ -10,7 +10,7 @@ final class StringColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->getSize();
     }
@@ -19,7 +19,7 @@ final class StringColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         $this->setSize($value);
         $this->setPrecision($value);

--- a/src/table/StructureChange.php
+++ b/src/table/StructureChange.php
@@ -71,7 +71,7 @@ final class StructureChange implements StructureChangeInterface
      * Returns value of the change based on the method.
      * @return mixed Change value
      */
-    public function getValue(string $schema = null, string $engineVersion = null)
+    public function getValue(?string $schema = null, ?string $engineVersion = null)
     {
         switch ($this->getMethod()) {
             case 'createTable':
@@ -112,7 +112,7 @@ final class StructureChange implements StructureChangeInterface
      * Returns create table value of the change.
      * @return array<ColumnInterface>
      */
-    private function getValueForCreateTable(string $engineName = null, string $engineVersion = null): array
+    private function getValueForCreateTable(?string $engineName = null, ?string $engineVersion = null): array
     {
         $columns = [];
 
@@ -168,7 +168,7 @@ final class StructureChange implements StructureChangeInterface
     /**
      * Returns add column value of the change.
      */
-    private function getValueForAddColumn(string $engineName = null, string $engineVersion = null): ColumnInterface
+    private function getValueForAddColumn(?string $engineName = null, ?string $engineVersion = null): ColumnInterface
     {
         $data = $this->getData();
         if (

--- a/src/table/StructureChangeInterface.php
+++ b/src/table/StructureChangeInterface.php
@@ -20,5 +20,5 @@ interface StructureChangeInterface
      * Returns value of the change based on the method.
      * @return mixed Change value
      */
-    public function getValue(string $schema = null, string $engineVersion = null);
+    public function getValue(?string $schema = null, ?string $engineVersion = null);
 }

--- a/src/table/TextColumn.php
+++ b/src/table/TextColumn.php
@@ -15,7 +15,7 @@ final class TextColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return \in_array($schema, $this->lengthSchemas, true) ? $this->getSize() : null;
     }
@@ -24,7 +24,7 @@ final class TextColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if (\in_array($schema, $this->lengthSchemas, true)) {
             $this->setSize($value);

--- a/src/table/TimeColumn.php
+++ b/src/table/TimeColumn.php
@@ -28,7 +28,7 @@ final class TimeColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->isSchemaLengthSupporting($schema, $engineVersion) ? $this->getPrecision() : null;
     }
@@ -37,7 +37,7 @@ final class TimeColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
             $this->setPrecision($value);

--- a/src/table/TimestampColumn.php
+++ b/src/table/TimestampColumn.php
@@ -44,7 +44,7 @@ final class TimestampColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         return $this->isSchemaLengthSupporting($schema, $engineVersion) ? $this->getPrecision() : null;
     }
@@ -53,7 +53,7 @@ final class TimestampColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
             $this->setPrecision($value);

--- a/src/table/TinyIntegerColumn.php
+++ b/src/table/TinyIntegerColumn.php
@@ -28,7 +28,7 @@ final class TinyIntegerColumn extends Column implements ColumnInterface
      * Returns length of the column.
      * @return int|string|null
      */
-    public function getLength(string $schema = null, string $engineVersion = null)
+    public function getLength(?string $schema = null, ?string $engineVersion = null)
     {
         $size = $this->getSize();
         if ($this->isSchemaLengthSupporting($schema, $engineVersion)) {
@@ -46,7 +46,7 @@ final class TinyIntegerColumn extends Column implements ColumnInterface
      * Sets length of the column.
      * @param string|int|null $value
      */
-    public function setLength($value, string $schema = null, string $engineVersion = null): void
+    public function setLength($value, ?string $schema = null, ?string $engineVersion = null): void
     {
         if (
             ($schema === Schema::MYSQL && (string)$value === '1')

--- a/tests/stubs/GeneratorStub.php
+++ b/tests/stubs/GeneratorStub.php
@@ -25,7 +25,7 @@ final class GeneratorStub implements GeneratorInterface
         array $referencesToPostpone = [],
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string {
         if (self::$throwForTable) {
             throw new Exception('Stub exception');
@@ -38,7 +38,7 @@ final class GeneratorStub implements GeneratorInterface
         string $migrationName,
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string {
         if (self::$throwForKeys) {
             throw new Exception('Stub exception');

--- a/tests/stubs/UpdaterStub.php
+++ b/tests/stubs/UpdaterStub.php
@@ -41,7 +41,7 @@ final class UpdaterStub implements UpdaterInterface
         string $migrationName,
         bool $usePrefix = true,
         string $dbPrefix = '',
-        string $namespace = null
+        ?string $namespace = null
     ): string {
         if (self::$throwForGenerate) {
             throw new NotSupportedException('Stub Exception');


### PR DESCRIPTION
Fixes for "Implicitly marking parameter as nullable is deprecated"