### PR TITLE
Fix 'Call to a member function getSchema() on string' in dummy Migration

### DIFF
--- a/src/dummy/MigrationChanges.php
+++ b/src/dummy/MigrationChanges.php
@@ -13,6 +13,7 @@ use ReflectionException;
 use yii\base\Component;
 use yii\base\InvalidArgumentException;
 use yii\base\NotSupportedException;
+use yii\di\Instance;
 
 /**
  * Dummy Migration class.
@@ -42,6 +43,7 @@ class Migration extends Component implements MigrationChangesInterface
     {
         parent::init();
 
+        $this->db = Instance::ensure($this->db, Connection::class);
         $this->db->getSchema()->refresh();
         $this->db->enableSlaves = false;
     }

--- a/src/dummy/MigrationSql.php
+++ b/src/dummy/MigrationSql.php
@@ -6,6 +6,7 @@ use bizley\migration\dummy\MigrationSqlInterface;
 use Generator;
 use yii\base\Component;
 use yii\base\NotSupportedException;
+use yii\di\Instance;
 
 /**
  * Dummy Migration class.
@@ -32,6 +33,7 @@ class Migration extends Component implements MigrationSqlInterface
     {
         parent::init();
 
+        $this->db = Instance::ensure($this->db, Connection::class);
         $this->db->getSchema()->refresh();
         $this->db->enableSlaves = false;
     }


### PR DESCRIPTION
When `migration/update` is run, the Extractor uses a dummy yii\db\Migration class (from src/dummy/MigrationChanges.php / MigrationSql.php) to replay old migrations without actually executing them. The dummy class's init() method calls $this->db->getSchema()->refresh() assuming $this->db is already a Connection object.
However, some user-defined migrations override $db in their own init() before calling parent::init():
```
public function init(): void
{
    $this->db = 'db'; // overwrites the Connection set by Yii::configure()
    parent::init();
}
```
The real yii\db\Migration::init() handles this by resolving the string to a Connection via Instance::ensure() before calling getSchema(). The dummy classes are missing this step, causing Call to a member function getSchema() on string.

This fix adds `use yii\di\Instance;` and call `$this->db = Instance::ensure($this->db, Connection::class);` in init() of both dummy classes, matching the real Migration class's behavior.